### PR TITLE
change "i" to "num" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ const array = [1, 2, 3, 4, 5];
 
 // groupBy groups items by arbitrary key.
 // In this case, we're grouping by even/odd keys
-array.groupBy(num => {
+array.groupBy((num, index, array) => {
   return num % 2 === 0 ? 'even': 'odd';
 });
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ const array = [1, 2, 3, 4, 5];
 
 // groupBy groups items by arbitrary key.
 // In this case, we're grouping by even/odd keys
-array.groupBy(i => {
-  return i % 2 === 0 ? 'even': 'odd';
+array.groupBy(num => {
+  return num % 2 === 0 ? 'even': 'odd';
 });
 
 // =>  { odd: [1, 3, 5], even: [2, 4] }


### PR DESCRIPTION
`i` when used with arrays conventionally refers to the item's index, which could mislead people to think that `i` here is an index, not the item's value.

re: https://github.com/tc39/proposal-array-grouping/issues/24