### PR TITLE
fix rendering of AddValueToKeyedGroup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head><meta charset="utf-8">
-<link rel="stylesheet" href="./spec.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><link rel="stylesheet" href="./spec.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <title>Array Grouping</title><script>'use strict';
@@ -190,7 +190,7 @@ function relevance(result) {
     relevance += 2048;
   }
 
-  relevance += Math.max(0, 255 - result.entry.key.length);
+  relevance += Math.max(0, 255 - result.key.length);
 
   return relevance;
 }
@@ -220,14 +220,15 @@ Search.prototype.search = function (searchString) {
 
     for (let i = 0; i < this.biblio.entries.length; i++) {
       let entry = this.biblio.entries[i];
-      if (!entry.key) {
+      let key = getKey(entry);
+      if (!key) {
         // biblio entries without a key aren't searchable
         continue;
       }
 
-      let match = fuzzysearch(searchString, entry.key);
+      let match = fuzzysearch(searchString, key);
       if (match) {
-        results.push({ entry, match });
+        results.push({ key, entry, match });
       }
     }
 
@@ -276,6 +277,7 @@ Search.prototype.displayResults = function (results) {
     let html = '<ul>';
 
     results.forEach(result => {
+      let key = result.key;
       let entry = result.entry;
       let id = entry.id;
       let cssClass = '';
@@ -283,19 +285,19 @@ Search.prototype.displayResults = function (results) {
 
       if (entry.type === 'clause') {
         let number = entry.number ? entry.number + ' ' : '';
-        text = number + entry.key;
+        text = number + key;
         cssClass = 'clause';
         id = entry.id;
       } else if (entry.type === 'production') {
-        text = entry.key;
+        text = key;
         cssClass = 'prod';
         id = entry.id;
       } else if (entry.type === 'op') {
-        text = entry.key;
+        text = key;
         cssClass = 'op';
         id = entry.id || entry.refId;
       } else if (entry.type === 'term') {
-        text = entry.key;
+        text = key;
         cssClass = 'term';
         id = entry.id || entry.refId;
       }
@@ -314,6 +316,31 @@ Search.prototype.displayResults = function (results) {
     this.$searchResults.classList.add('no-results');
   }
 };
+
+function getKey(item) {
+  if (item.key) {
+    return item.key;
+  }
+  switch (item.type) {
+    case 'clause':
+      return item.title || item.titleHTML;
+    case 'production':
+      return item.name;
+    case 'op':
+      return item.aoid;
+    case 'term':
+      return item.term;
+    case 'table':
+    case 'figure':
+    case 'example':
+    case 'note':
+      return item.caption;
+    case 'step':
+      return item.id;
+    default:
+      throw new Error("Can't get key for " + item.type);
+  }
+}
 
 function Menu() {
   this.$toggle = document.getElementById('menu-toggle');
@@ -507,7 +534,7 @@ Menu.prototype.addPinEntry = function (id) {
     // prettier-ignore
     this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${prefix}${entry.titleHTML}</a></li>`;
   } else {
-    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${entry.key}</a></li>`;
+    this.$pinList.innerHTML += `<li><a href="${makeLinkToId(entry.id)}">${getKey(entry)}</a></li>`;
   }
 
   if (Object.keys(this._pinnedIds).length === 0) {
@@ -570,24 +597,6 @@ Menu.prototype.selectPin = function (num) {
 };
 
 let menu;
-function init() {
-  menu = new Menu();
-  let $container = document.getElementById('spec-container');
-  $container.addEventListener(
-    'mouseover',
-    debounce(e => {
-      Toolbox.activateIfMouseOver(e);
-    })
-  );
-  document.addEventListener(
-    'keydown',
-    debounce(e => {
-      if (e.code === 'Escape' && Toolbox.active) {
-        Toolbox.deactivate();
-      }
-    })
-  );
-}
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -610,18 +619,17 @@ function debounce(fn, opts) {
 }
 
 let CLAUSE_NODES = ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX'];
-function findLocalReferences($elem) {
-  let name = $elem.innerHTML;
-  let references = [];
-
+function findContainer($elem) {
   let parentClause = $elem.parentNode;
   while (parentClause && CLAUSE_NODES.indexOf(parentClause.nodeName) === -1) {
     parentClause = parentClause.parentNode;
   }
+  return parentClause;
+}
 
-  if (!parentClause) return;
-
+function findLocalReferences(parentClause, name) {
   let vars = parentClause.querySelectorAll('var');
+  let references = [];
 
   for (let i = 0; i < vars.length; i++) {
     let $var = vars[i];
@@ -634,15 +642,32 @@ function findLocalReferences($elem) {
   return references;
 }
 
+let REFERENCED_CLASSES = Array.from({ length: 7 }, (x, i) => `referenced${i}`);
+function chooseHighlightIndex(parentClause) {
+  let counts = REFERENCED_CLASSES.map($class => parentClause.getElementsByClassName($class).length);
+  // Find the earliest index with the lowest count.
+  let minCount = Infinity;
+  let index = null;
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] < minCount) {
+      minCount = counts[i];
+      index = i;
+    }
+  }
+  return index;
+}
+
 function toggleFindLocalReferences($elem) {
-  let references = findLocalReferences($elem);
+  let parentClause = findContainer($elem);
+  let references = findLocalReferences(parentClause, $elem.innerHTML);
   if ($elem.classList.contains('referenced')) {
     references.forEach($reference => {
-      $reference.classList.remove('referenced');
+      $reference.classList.remove('referenced', ...REFERENCED_CLASSES);
     });
   } else {
+    let index = chooseHighlightIndex(parentClause);
     references.forEach($reference => {
-      $reference.classList.add('referenced');
+      $reference.classList.add('referenced', `referenced${index}`);
     });
   }
 }
@@ -721,6 +746,145 @@ function fuzzysearch(searchString, haystack, caseInsensitive) {
 
   return { caseMatch: !caseInsensitive, chunks, prefix: j <= qlen };
 }
+
+let referencePane = {
+  init() {
+    this.$container = document.createElement('div');
+    this.$container.setAttribute('id', 'references-pane-container');
+
+    let $spacer = document.createElement('div');
+    $spacer.setAttribute('id', 'references-pane-spacer');
+
+    this.$pane = document.createElement('div');
+    this.$pane.setAttribute('id', 'references-pane');
+
+    this.$container.appendChild($spacer);
+    this.$container.appendChild(this.$pane);
+
+    this.$header = document.createElement('div');
+    this.$header.classList.add('menu-pane-header');
+    this.$headerText = document.createElement('span');
+    this.$header.appendChild(this.$headerText);
+    this.$headerRefId = document.createElement('a');
+    this.$header.appendChild(this.$headerRefId);
+    this.$closeButton = document.createElement('span');
+    this.$closeButton.setAttribute('id', 'references-pane-close');
+    this.$closeButton.addEventListener('click', () => {
+      this.deactivate();
+    });
+    this.$header.appendChild(this.$closeButton);
+
+    this.$pane.appendChild(this.$header);
+    let tableContainer = document.createElement('div');
+    tableContainer.setAttribute('id', 'references-pane-table-container');
+
+    this.$table = document.createElement('table');
+    this.$table.setAttribute('id', 'references-pane-table');
+
+    this.$tableBody = this.$table.createTBody();
+
+    tableContainer.appendChild(this.$table);
+    this.$pane.appendChild(tableContainer);
+
+    menu.$specContainer.appendChild(this.$container);
+  },
+
+  activate() {
+    this.$container.classList.add('active');
+  },
+
+  deactivate() {
+    this.$container.classList.remove('active');
+    this.state = null;
+  },
+
+  showReferencesFor(entry) {
+    this.activate();
+    this.state = { type: 'ref', id: entry.id };
+    this.$headerText.textContent = 'References to ';
+    let newBody = document.createElement('tbody');
+    let previousId;
+    let previousCell;
+    let dupCount = 0;
+    this.$headerRefId.textContent = '#' + entry.id;
+    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
+    this.$headerRefId.style.display = 'inline';
+    (entry.referencingIds || [])
+      .map(id => {
+        let cid = menu.search.biblio.refParentClause[id];
+        let clause = menu.search.biblio.byId[cid];
+        if (clause == null) {
+          throw new Error('could not find clause for id ' + cid);
+        }
+        return { id, clause };
+      })
+      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
+      .forEach(record => {
+        if (previousId === record.clause.id) {
+          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
+          dupCount++;
+        } else {
+          let row = newBody.insertRow();
+          let cell = row.insertCell();
+          cell.innerHTML = record.clause.number;
+          cell = row.insertCell();
+          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
+          previousCell = cell;
+          previousId = record.clause.id;
+          dupCount = 0;
+        }
+      }, this);
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+
+  showSDOs(sdos, alternativeId) {
+    let rhs = document.getElementById(alternativeId);
+    let parentName = rhs.parentNode.getAttribute('name');
+    let colons = rhs.parentNode.querySelector('emu-geq');
+    rhs = rhs.cloneNode(true);
+    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
+      e.remove();
+    });
+    rhs.querySelectorAll('[id]').forEach(e => {
+      e.removeAttribute('id');
+    });
+    rhs.querySelectorAll('a').forEach(e => {
+      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
+    });
+
+    // prettier-ignore
+    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
+    this.$headerText.querySelector('a').append(rhs);
+    this.showSDOsBody(sdos, alternativeId);
+  },
+
+  showSDOsBody(sdos, alternativeId) {
+    this.activate();
+    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
+    this.$headerRefId.style.display = 'none';
+    let newBody = document.createElement('tbody');
+    Object.keys(sdos).forEach(sdoName => {
+      let pair = sdos[sdoName];
+      let clause = pair.clause;
+      let ids = pair.ids;
+      let first = ids[0];
+      let row = newBody.insertRow();
+      let cell = row.insertCell();
+      cell.innerHTML = clause;
+      cell = row.insertCell();
+      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
+      for (let i = 1; i < ids.length; ++i) {
+        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
+      }
+      cell.innerHTML = html;
+    });
+    this.$table.removeChild(this.$tableBody);
+    this.$tableBody = newBody;
+    this.$table.appendChild(this.$tableBody);
+  },
+};
 
 let Toolbox = {
   init() {
@@ -842,145 +1006,6 @@ let Toolbox = {
   },
 };
 
-let referencePane = {
-  init() {
-    this.$container = document.createElement('div');
-    this.$container.setAttribute('id', 'references-pane-container');
-
-    let $spacer = document.createElement('div');
-    $spacer.setAttribute('id', 'references-pane-spacer');
-
-    this.$pane = document.createElement('div');
-    this.$pane.setAttribute('id', 'references-pane');
-
-    this.$container.appendChild($spacer);
-    this.$container.appendChild(this.$pane);
-
-    this.$header = document.createElement('div');
-    this.$header.classList.add('menu-pane-header');
-    this.$headerText = document.createElement('span');
-    this.$header.appendChild(this.$headerText);
-    this.$headerRefId = document.createElement('a');
-    this.$header.appendChild(this.$headerRefId);
-    this.$closeButton = document.createElement('span');
-    this.$closeButton.setAttribute('id', 'references-pane-close');
-    this.$closeButton.addEventListener('click', () => {
-      this.deactivate();
-    });
-    this.$header.appendChild(this.$closeButton);
-
-    this.$pane.appendChild(this.$header);
-    let tableContainer = document.createElement('div');
-    tableContainer.setAttribute('id', 'references-pane-table-container');
-
-    this.$table = document.createElement('table');
-    this.$table.setAttribute('id', 'references-pane-table');
-
-    this.$tableBody = this.$table.createTBody();
-
-    tableContainer.appendChild(this.$table);
-    this.$pane.appendChild(tableContainer);
-
-    menu.$specContainer.appendChild(this.$container);
-  },
-
-  activate() {
-    this.$container.classList.add('active');
-  },
-
-  deactivate() {
-    this.$container.classList.remove('active');
-    this.state = null;
-  },
-
-  showReferencesFor(entry) {
-    this.activate();
-    this.state = { type: 'ref', id: entry.id };
-    this.$headerText.textContent = 'References to ';
-    let newBody = document.createElement('tbody');
-    let previousId;
-    let previousCell;
-    let dupCount = 0;
-    this.$headerRefId.textContent = '#' + entry.id;
-    this.$headerRefId.setAttribute('href', makeLinkToId(entry.id));
-    this.$headerRefId.style.display = 'inline';
-    entry.referencingIds
-      .map(id => {
-        let cid = menu.search.biblio.refParentClause[id];
-        let clause = menu.search.biblio.byId[cid];
-        if (clause == null) {
-          throw new Error('could not find clause for id ' + cid);
-        }
-        return { id, clause };
-      })
-      .sort((a, b) => sortByClauseNumber(a.clause, b.clause))
-      .forEach(record => {
-        if (previousId === record.clause.id) {
-          previousCell.innerHTML += ` (<a href="${makeLinkToId(record.id)}">${dupCount + 2}</a>)`;
-          dupCount++;
-        } else {
-          let row = newBody.insertRow();
-          let cell = row.insertCell();
-          cell.innerHTML = record.clause.number;
-          cell = row.insertCell();
-          cell.innerHTML = `<a href="${makeLinkToId(record.id)}">${record.clause.titleHTML}</a>`;
-          previousCell = cell;
-          previousId = record.clause.id;
-          dupCount = 0;
-        }
-      }, this);
-    this.$table.removeChild(this.$tableBody);
-    this.$tableBody = newBody;
-    this.$table.appendChild(this.$tableBody);
-  },
-
-  showSDOs(sdos, alternativeId) {
-    let rhs = document.getElementById(alternativeId);
-    let parentName = rhs.parentNode.getAttribute('name');
-    let colons = rhs.parentNode.querySelector('emu-geq');
-    rhs = rhs.cloneNode(true);
-    rhs.querySelectorAll('emu-params,emu-constraints').forEach(e => {
-      e.remove();
-    });
-    rhs.querySelectorAll('[id]').forEach(e => {
-      e.removeAttribute('id');
-    });
-    rhs.querySelectorAll('a').forEach(e => {
-      e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
-    });
-
-    // prettier-ignore
-    this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
-    this.$headerText.querySelector('a').append(rhs);
-    this.showSDOsBody(sdos, alternativeId);
-  },
-
-  showSDOsBody(sdos, alternativeId) {
-    this.activate();
-    this.state = { type: 'sdo', id: alternativeId, html: this.$headerText.innerHTML };
-    this.$headerRefId.style.display = 'none';
-    let newBody = document.createElement('tbody');
-    Object.keys(sdos).forEach(sdoName => {
-      let pair = sdos[sdoName];
-      let clause = pair.clause;
-      let ids = pair.ids;
-      let first = ids[0];
-      let row = newBody.insertRow();
-      let cell = row.insertCell();
-      cell.innerHTML = clause;
-      cell = row.insertCell();
-      let html = '<a href="' + makeLinkToId(first) + '">' + sdoName + '</a>';
-      for (let i = 1; i < ids.length; ++i) {
-        html += ' (<a href="' + makeLinkToId(ids[i]) + '">' + (i + 1) + '</a>)';
-      }
-      cell.innerHTML = html;
-    });
-    this.$table.removeChild(this.$tableBody);
-    this.$tableBody = newBody;
-    this.$table.appendChild(this.$tableBody);
-  },
-};
-
 function sortByClauseNumber(clause1, clause2) {
   let c1c = clause1.number.split('.');
   let c2c = clause2.number.split('.');
@@ -1036,7 +1061,10 @@ function doShortcut(e) {
   if (name === 'textarea' || name === 'input' || name === 'select' || target.isContentEditable) {
     return;
   }
-  if (e.key === 'm' && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && usesMultipage) {
+  if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+    return;
+  }
+  if (e.key === 'm' && usesMultipage) {
     let pathParts = location.pathname.split('/');
     let hash = location.hash;
     if (pathParts[pathParts.length - 2] === 'multipage') {
@@ -1053,7 +1081,28 @@ function doShortcut(e) {
     } else {
       location = 'multipage/' + hash;
     }
+  } else if (e.key === 'u') {
+    document.documentElement.classList.toggle('show-ao-annotations');
   }
+}
+
+function init() {
+  menu = new Menu();
+  let $container = document.getElementById('spec-container');
+  $container.addEventListener(
+    'mouseover',
+    debounce(e => {
+      Toolbox.activateIfMouseOver(e);
+    })
+  );
+  document.addEventListener(
+    'keydown',
+    debounce(e => {
+      if (e.code === 'Escape' && Toolbox.active) {
+        Toolbox.deactivate();
+      }
+    })
+  );
 }
 
 document.addEventListener('keypress', doShortcut);
@@ -1095,7 +1144,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-array.prototype.groupby":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8"],"sec-array.prototype.groupbymap":["_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16"],"sec-add-value-to-keyed-group":["_ref_17"]},"entries":[{"type":"clause","id":"sec-scope","aoid":null,"titleHTML":"Scope","number":"1","referencingIds":[],"key":"Scope"},{"type":"clause","id":"sec-array.prototype.groupby","aoid":null,"titleHTML":"Array.prototype.groupBy ( <var>callbackfn</var> [ , <var>thisArg</var> ] )","number":"2.1","referencingIds":[],"key":"Array.prototype.groupBy ( callbackfn [ , thisArg ] )"},{"type":"clause","id":"sec-array.prototype.groupbymap","aoid":null,"titleHTML":"Array.prototype.groupByMap ( <var>callbackfn</var> [ , <var>thisArg</var> ] )","number":"2.2","referencingIds":[],"key":"Array.prototype.groupByMap ( callbackfn [ , thisArg ] )"},{"type":"clause","id":"sec-add-value-to-keyed-group","aoid":null,"titleHTML":"\\n      AddValueToKeyedGroup (\\n        <var>groups</var>: a List of Records that have [[Key]] and [[Elements]] fields,\\n        <var>key</var>: an ECMAScript language value,\\n        <var>value</var>: an ECMAScript language value,\\n      )\\n    ","number":"2.3","referencingIds":[],"key":"\\n      AddValueToKeyedGroup (\\n        groups: a List of Records that have [[Key]] and [[Elements]] fields,\\n        key: an ECMAScript language value,\\n        value: an ECMAScript language value,\\n      )\\n    "},{"type":"clause","id":"sec-properties-of-the-array-prototype-object","aoid":null,"titleHTML":"Properties of the Array Prototype Object (<a href=\\"https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object\\">22.1.3</a>)","number":"2","referencingIds":[],"key":"Properties of the Array Prototype Object (22.1.3)"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"titleHTML":"Copyright &amp; Software License","number":"A","referencingIds":[],"key":"Copyright & Software License"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-array.prototype.groupby":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9"],"sec-array.prototype.groupbymap":["_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18"],"sec-add-value-to-keyed-group":["_ref_19"]},"entries":[{"type":"clause","id":"sec-scope","titleHTML":"Scope","number":"1"},{"type":"clause","id":"sec-array.prototype.groupby","title":"Array.prototype.groupBy ( callbackfn [ , thisArg ] )","titleHTML":"Array.prototype.groupBy ( <var>callbackfn</var> [ , <var>thisArg</var> ] )","number":"2.1"},{"type":"clause","id":"sec-array.prototype.groupbymap","title":"Array.prototype.groupByMap ( callbackfn [ , thisArg ] )","titleHTML":"Array.prototype.groupByMap ( <var>callbackfn</var> [ , <var>thisArg</var> ] )","number":"2.2"},{"type":"op","aoid":"AddValueToKeyedGroup","refId":"sec-add-value-to-keyed-group"},{"type":"clause","id":"sec-add-value-to-keyed-group","title":"AddValueToKeyedGroup ( groups, key, value )","titleHTML":"AddValueToKeyedGroup ( <var>groups</var>, <var>key</var>, <var>value</var> )","number":"2.3","referencingIds":["_ref_7","_ref_16"]},{"type":"clause","id":"sec-properties-of-the-array-prototype-object","titleHTML":"Properties of the Array Prototype Object (22.1.3)","number":"2"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -1133,6 +1182,43 @@ a:hover {
   color: #239dee;
 }
 
+a.e-user-code,
+span.e-user-code {
+  white-space: nowrap;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  display: none;
+  color: brown;
+  background-color: white;
+  border: 2pt solid brown;
+  padding: 0.3ex;
+  margin: 0 0.25em 0 0;
+  line-height: 1;
+  vertical-align: text-top;
+  text-transform: uppercase;
+  font-family: "Comic Code", sans-serif;
+  font-weight: 900;
+  font-size: x-small;
+}
+
+a.e-user-code:hover::before,
+span.e-user-code:hover::before {
+  background-color: brown;
+  color: white;
+}
+
+html.show-ao-annotations a.e-user-code::before,
+html.show-ao-annotations span.e-user-code::before {
+  display: inline-block;
+}
+
+a.e-user-code::before,
+span.e-user-code::before {
+  content: 'UC';
+}
+
 code {
   font-weight: bold;
   font-family: Consolas, Monaco, monospace;
@@ -1165,8 +1251,40 @@ var {
   cursor: pointer;
 }
 
-var.referenced {
+var.referenced0 {
+  color: inherit;
   background-color: #ffff33;
+  box-shadow: 0 0 0 2px #ffff33;
+}
+var.referenced1 {
+  color: inherit;
+  background-color: #ff87a2;
+  box-shadow: 0 0 0 2px #ff87a2;
+}
+var.referenced2 {
+  color: inherit;
+  background-color: #96e885;
+  box-shadow: 0 0 0 2px #96e885;
+}
+var.referenced3 {
+  color: inherit;
+  background-color: #3eeed2;
+  box-shadow: 0 0 0 2px #3eeed2;
+}
+var.referenced4 {
+  color: inherit;
+  background-color: #eacfb6;
+  box-shadow: 0 0 0 2px #eacfb6;
+}
+var.referenced5 {
+  color: inherit;
+  background-color: #82ddff;
+  box-shadow: 0 0 0 2px #82ddff;
+}
+var.referenced6 {
+  color: inherit;
+  background-color: #ffbcf2;
+  box-shadow: 0 0 0 2px #ffbcf2;
 }
 
 emu-const {
@@ -2225,34 +2343,26 @@ li.menu-search-result-term:before {
   }
 }
 
-[normative-optional] {
+[normative-optional],
+[legacy] {
   border-left: 5px solid #ff6600;
   padding: 0.5em;
   display: block;
   background: #ffeedd;
 }
 
-.normative-optional-tag {
+.clause-attributes-tag {
   text-transform: uppercase;
   color: #884400;
 }
 
-.normative-optional-tag a {
+.clause-attributes-tag a {
   color: #884400;
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-scope" title="Scope"><span class="secnum">1</span> Scope</a></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-array-prototype-object" title="Properties of the Array Prototype Object (22.1.3)"><span class="secnum">2</span> Properties of the Array Prototype Object (</a><a href="https://tc39.es/ecma262/#sec-properties-of-the-array-prototype-object">22.1.3</a>)<ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-array.prototype.groupby" title="Array.prototype.groupBy ( callbackfn [ , thisArg ] )"><span class="secnum">2.1</span> Array.prototype.groupBy ( <var>callbackfn</var> [ , <var>thisArg</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-array.prototype.groupbymap" title="Array.prototype.groupByMap ( callbackfn [ , thisArg ] )"><span class="secnum">2.2</span> Array.prototype.groupByMap ( <var>callbackfn</var> [ , <var>thisArg</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-add-value-to-keyed-group" title="
-      AddValueToKeyedGroup (
-        groups: a List of Records that have [[Key]] and [[Elements]] fields,
-        key: an ECMAScript language value,
-        value: an ECMAScript language value,
-      )
-    "><span class="secnum">2.3</span> 
-      AddValueToKeyedGroup (
-        <var>groups</var>: a List of Records that have [[Key]] and [[Elements]] fields,
-        <var>key</var>: an ECMAScript language value,
-        <var>value</var>: an ECMAScript language value,
-      )
-    </a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / November 15, 2021</h1><h1 class="title">Array Grouping</h1>
+</style></head><body><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+      <title>Menu</title>
+      <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-scope" title="Scope"><span class="secnum">1</span> Scope</a></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-array-prototype-object" title="Properties of the Array Prototype Object (22.1.3)"><span class="secnum">2</span> Properties of the Array Prototype Object (22.1.3)</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-array.prototype.groupby" title="Array.prototype.groupBy ( callbackfn [ , thisArg ] )"><span class="secnum">2.1</span> Array.prototype.groupBy ( <var>callbackfn</var> [ , <var>thisArg</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-array.prototype.groupbymap" title="Array.prototype.groupByMap ( callbackfn [ , thisArg ] )"><span class="secnum">2.2</span> Array.prototype.groupByMap ( <var>callbackfn</var> [ , <var>thisArg</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-add-value-to-keyed-group" title="AddValueToKeyedGroup ( groups, key, value )"><span class="secnum">2.3</span> AddValueToKeyedGroup ( <var>groups</var>, <var>key</var>, <var>value</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / November 23, 2021</h1><h1 class="title">Array Grouping</h1>
 
 <emu-clause id="sec-scope">
   <h1><span class="secnum">1</span> Scope</h1>
@@ -2276,7 +2386,7 @@ li.menu-search-result-term:before {
       <p>The return value of <code>groupBy</code> is an object that does not inherit from <var>Object.prototype</var>.</p>
     </div></emu-note>
     <p>When the <code>groupBy</code> method is called with one or two arguments, the following steps are taken:</p>
-    <emu-alg><ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_0"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<emu-val>this</emu-val> value).</li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="LengthOfArrayLike" id="_ref_1"><a href="https://tc39.es/ecma262/#sec-lengthofarraylike">LengthOfArrayLike</a></emu-xref>(<var>O</var>).</li><li>If <emu-xref aoid="IsCallable" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>callbackfn</var>) is <emu-val>false</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>k</var> be 0.</li><li>Let <var>groups</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Repeat, while <var>k</var> &lt; <var>len</var><ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_3"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>)).</li><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_4"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>Let <var>propertyKey</var> be ?&nbsp;<emu-xref aoid="ToPropertyKey" id="_ref_5"><a href="https://tc39.es/ecma262/#sec-topropertykey">ToPropertyKey</a></emu-xref>(? <emu-xref aoid="Call" id="_ref_6"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>callbackfn</var>, <var>thisArg</var>, « <var>kValue</var>, <emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>), <var>O</var> »)).</li><li>Perform !&nbsp;AddValueToKeyedGroup(<var>groups</var>, <var>propertyKey</var>, <var>kValue</var>).</li><li>Set <var>k</var> to <var>k</var> + 1.</li></ol></li><li>Let <var>obj</var> be !&nbsp;OrdinaryObjectCreate(<emu-val>null</emu-val>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]], [[Elements]] } <var>g</var> of <var>groups</var>, do<ol><li>Let <var>elements</var> be !&nbsp;<emu-xref aoid="CreateArrayFromList" id="_ref_7"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>g</var>.[[Elements]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_8"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>obj</var>, <var>g</var>.[[Key]], <var>elements</var>).</li></ol></li><li>Return <var>obj</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_0"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<emu-val>this</emu-val> value).</li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="LengthOfArrayLike" id="_ref_1"><a href="https://tc39.es/ecma262/#sec-lengthofarraylike">LengthOfArrayLike</a></emu-xref>(<var>O</var>).</li><li>If <emu-xref aoid="IsCallable" id="_ref_2"><a href="https://tc39.es/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>callbackfn</var>) is <emu-val>false</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>k</var> be 0.</li><li>Let <var>groups</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Repeat, while <var>k</var> &lt; <var>len</var><ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_3"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>)).</li><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_4"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>Let <var>propertyKey</var> be ?&nbsp;<emu-xref aoid="ToPropertyKey" id="_ref_5"><a href="https://tc39.es/ecma262/#sec-topropertykey">ToPropertyKey</a></emu-xref>(? <emu-xref aoid="Call" id="_ref_6"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>callbackfn</var>, <var>thisArg</var>, « <var>kValue</var>, <emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>), <var>O</var> »)).</li><li>Perform !&nbsp;<emu-xref aoid="AddValueToKeyedGroup" id="_ref_7"><a href="#sec-add-value-to-keyed-group">AddValueToKeyedGroup</a></emu-xref>(<var>groups</var>, <var>propertyKey</var>, <var>kValue</var>).</li><li>Set <var>k</var> to <var>k</var> + 1.</li></ol></li><li>Let <var>obj</var> be !&nbsp;OrdinaryObjectCreate(<emu-val>null</emu-val>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]], [[Elements]] } <var>g</var> of <var>groups</var>, do<ol><li>Let <var>elements</var> be !&nbsp;<emu-xref aoid="CreateArrayFromList" id="_ref_8"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>g</var>.[[Elements]]).</li><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>obj</var>, <var>g</var>.[[Key]], <var>elements</var>).</li></ol></li><li>Return <var>obj</var>.</li></ol></emu-alg>
     <emu-note><span class="note">Note 2</span><div class="note-contents">
       <p>The <code>groupBy</code> function is intentionally generic; it does not require that its <emu-val>this</emu-val> value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
     </div></emu-note>
@@ -2295,21 +2405,16 @@ li.menu-search-result-term:before {
       <p>The return value of <code>groupByMap</code> is a Map.</p>
     </div></emu-note>
     <p>When the <code>groupByMap</code> method is called with one or two arguments, the following steps are taken:</p>
-    <emu-alg><ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<emu-val>this</emu-val> value).</li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="LengthOfArrayLike" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-lengthofarraylike">LengthOfArrayLike</a></emu-xref>(<var>O</var>).</li><li>If <emu-xref aoid="IsCallable" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>callbackfn</var>) is <emu-val>false</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>k</var> be 0.</li><li>Let <var>groups</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Repeat, while <var>k</var> &lt; <var>len</var><ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>)).</li><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>Let <var>key</var> be ?&nbsp;<emu-xref aoid="Call" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>callbackfn</var>, <var>thisArg</var>, « <var>kValue</var>, <emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>), <var>O</var> »).</li><li>If <var>key</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, set <var>key</var> to <emu-val>+0</emu-val><sub>𝔽</sub>.</li><li>Perform !&nbsp;AddValueToKeyedGroup(<var>groups</var>, <var>key</var>, <var>kValue</var>).</li><li>Set <var>k</var> to <var>k</var> + 1.</li></ol></li><li>Let <var>map</var> be !&nbsp;<emu-xref aoid="Construct" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-construct">Construct</a></emu-xref>(<emu-xref href="#sec-map-constructor"><a href="https://tc39.es/ecma262/#sec-map-constructor">%Map%</a></emu-xref>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]], [[Elements]] } <var>g</var> of <var>groups</var>, do<ol><li>Let <var>elements</var> be !&nbsp;<emu-xref aoid="CreateArrayFromList" id="_ref_16"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>g</var>.[[Elements]]).</li><li>Let <var>entry</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>g</var>.[[Key]], [[Value]]: <var>elements</var> }.</li><li>Append <var>entry</var> as the last element of <var>map</var>.[[MapData]].</li></ol></li><li>Return <var>map</var>.</li></ol></emu-alg>
+    <emu-alg><ol><li>Let <var>O</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<emu-val>this</emu-val> value).</li><li>Let <var>len</var> be ?&nbsp;<emu-xref aoid="LengthOfArrayLike" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-lengthofarraylike">LengthOfArrayLike</a></emu-xref>(<var>O</var>).</li><li>If <emu-xref aoid="IsCallable" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>callbackfn</var>) is <emu-val>false</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>k</var> be 0.</li><li>Let <var>groups</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>Repeat, while <var>k</var> &lt; <var>len</var><ol><li>Let <var>Pk</var> be !&nbsp;<emu-xref aoid="ToString" id="_ref_13"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>)).</li><li>Let <var>kValue</var> be ?&nbsp;<emu-xref aoid="Get" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>O</var>, <var>Pk</var>).</li><li>Let <var>key</var> be ?&nbsp;<emu-xref aoid="Call" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>callbackfn</var>, <var>thisArg</var>, « <var>kValue</var>, <emu-xref href="#𝔽"><a href="https://tc39.es/ecma262/#𝔽">𝔽</a></emu-xref>(<var>k</var>), <var>O</var> »).</li><li>If <var>key</var> is <emu-val>-0</emu-val><sub>𝔽</sub>, set <var>key</var> to <emu-val>+0</emu-val><sub>𝔽</sub>.</li><li>Perform !&nbsp;<emu-xref aoid="AddValueToKeyedGroup" id="_ref_16"><a href="#sec-add-value-to-keyed-group">AddValueToKeyedGroup</a></emu-xref>(<var>groups</var>, <var>key</var>, <var>kValue</var>).</li><li>Set <var>k</var> to <var>k</var> + 1.</li></ol></li><li>Let <var>map</var> be !&nbsp;<emu-xref aoid="Construct" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-construct">Construct</a></emu-xref>(<emu-xref href="#sec-map-constructor"><a href="https://tc39.es/ecma262/#sec-map-constructor">%Map%</a></emu-xref>).</li><li>For each <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]], [[Elements]] } <var>g</var> of <var>groups</var>, do<ol><li>Let <var>elements</var> be !&nbsp;<emu-xref aoid="CreateArrayFromList" id="_ref_18"><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">CreateArrayFromList</a></emu-xref>(<var>g</var>.[[Elements]]).</li><li>Let <var>entry</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>g</var>.[[Key]], [[Value]]: <var>elements</var> }.</li><li>Append <var>entry</var> as the last element of <var>map</var>.[[MapData]].</li></ol></li><li>Return <var>map</var>.</li></ol></emu-alg>
     <emu-note><span class="note">Note 2</span><div class="note-contents">
       <p>The <code>groupBy</code> function is intentionally generic; it does not require that its <emu-val>this</emu-val> value be an Array object. Therefore it can be transferred to other kinds of objects for use as a method.</p>
     </div></emu-note>
   </emu-clause>
 
-  <emu-clause id="sec-add-value-to-keyed-group" type="abstract operation">
-    <h1><span class="secnum">2.3</span> 
-      AddValueToKeyedGroup (
-        <var>groups</var>: a List of Records that have [[Key]] and [[Elements]] fields,
-        <var>key</var>: an ECMAScript language value,
-        <var>value</var>: an ECMAScript language value,
-      )
-    </h1>
-    <emu-alg><ol><li>If <var>groups</var> contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>g</var> such that !&nbsp;<emu-xref aoid="SameValueZero" id="_ref_17"><a href="https://tc39.es/ecma262/#sec-samevaluezero">SameValueZero</a></emu-xref>(<var>g</var>.[[Key]], <var>key</var>) is <emu-val>true</emu-val>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: exactly one element of <var>groups</var> meets this criteria.</li><li>Append <var>value</var> as the last element of <var>g</var>.[[Elements]].</li></ol></li><li>Else,<ol><li>Let <var>group</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>key</var>, [[Elements]]: « <var>value</var> » }.</li><li>Append <var>group</var> as the last element of <var>groups</var>.</li></ol></li></ol></emu-alg>
+  <emu-clause id="sec-add-value-to-keyed-group" type="abstract operation" aoid="AddValueToKeyedGroup">
+    <h1><span class="secnum">2.3</span> AddValueToKeyedGroup ( <var>groups</var>, <var>key</var>, <var>value</var> )</h1>
+    <p>The abstract operation AddValueToKeyedGroup takes arguments <var>groups</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of Records that have [[Key]] and [[Elements]] fields), <var>key</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), and <var>value</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>). It performs the following steps when called:</p>
+    <emu-alg><ol><li>If <var>groups</var> contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>g</var> such that !&nbsp;<emu-xref aoid="SameValueZero" id="_ref_19"><a href="https://tc39.es/ecma262/#sec-samevaluezero">SameValueZero</a></emu-xref>(<var>g</var>.[[Key]], <var>key</var>) is <emu-val>true</emu-val>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: exactly one element of <var>groups</var> meets this criteria.</li><li>Append <var>value</var> as the last element of <var>g</var>.[[Elements]].</li></ol></li><li>Else,<ol><li>Let <var>group</var> be the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Key]]: <var>key</var>, [[Elements]]: « <var>value</var> » }.</li><li>Append <var>group</var> as the last element of <var>groups</var>.</li></ol></li></ol></emu-alg>
   </emu-clause>
   </ins>
 </emu-clause><emu-annex id="sec-copyright-and-software-license">

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "ecmarkup": "^7.0.3"
+    "ecmarkup": "^9.6.3"
   }
 }

--- a/spec.emu
+++ b/spec.emu
@@ -102,6 +102,8 @@ location: https://tc39.es/proposal-array-grouping/
         _value_: an ECMAScript language value,
       )
     </h1>
+    <dl class="header">
+    </dl>
     <emu-alg>
         1. If _groups_ contains a Record _g_ such that ! SameValueZero(_g_.[[Key]], _key_) is *true*, then
           1. Assert: exactly one element of _groups_ meets this criteria.


### PR DESCRIPTION
AddValueToKeyedGroup uses a structured header, support for which was only introduced in ecmarkup 8.0.0. Also, it omitted the currently-required `<dl class="header">` which marks it as a structured header. (We'll probably drop the requirement to include that element as a marker at some point, but it's needed for now.)

This fixes both issues.