### PR TITLE
use SameValue in AddValueToKeyedGroup

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -105,7 +105,7 @@ location: https://tc39.es/proposal-array-grouping/
     <dl class="header">
     </dl>
     <emu-alg>
-        1. If _groups_ contains a Record _g_ such that ! SameValueZero(_g_.[[Key]], _key_) is *true*, then
+        1. If _groups_ contains a Record _g_ such that ! SameValue(_g_.[[Key]], _key_) is *true*, then
           1. Assert: exactly one element of _groups_ meets this criteria.
           1. Append _value_ as the last element of _g_.[[Elements]].
         1. Else,


### PR DESCRIPTION
This should be functionally identical, but logically simpler since it doesn't include any special handling of zeroes. We've already replaced all `-0` with `+0` in `groupByMap`, and `groupBy` only ever passes in property keys.